### PR TITLE
Build final SemVer Docker images

### DIFF
--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,9 +1,10 @@
 # When a PR is merged into main, determine the next semver release based on conventional commits,
-# cut a GitHub release and build a push a Docker image into ECR.
+# cut a GitHub release containing build binaries and build and push a Docker image into ECR.
 name: auto-releaser
 on:
   push:
-    branches: main
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -15,6 +16,8 @@ jobs:
 
     env:
       SERVICE_NAME: user-mgmt-service-api
+      AWS_REGION: "eu-west-2"
+      AWS_ACCOUNT_ID: "633681147894"
 
     steps:
       - name: Clone git repo
@@ -28,11 +31,12 @@ jobs:
         id: releaser
         with:
           # We cannot use the default GITHUB_TOKEN as this user does not trigger workflows automatically
-          # Required so that the release workflow runs once we have merged the release PR
+          # Required so that this workflow re-runs once we have merged the release PR
           token: ${{ secrets.GH_PAT }}
           release-type: go
 
       - name: setup-go
+        if: ${{ steps.releaser.outputs.release_created }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -42,9 +46,7 @@ jobs:
         env:
           BUILD_VERSION: ${{ steps.releaser.outputs.tag_name }}
         run: |
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-X main.BuildVersion=${{ env.BUILD_VERSION }}" -o ${{env.SERVICE_NAME }}-linux-amd64 ./cmd/main.go
           GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-X main.BuildVersion=${{ env.BUILD_VERSION }}" -o ${{env.SERVICE_NAME }}-linux-arm64 ./cmd/main.go
-          GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-X main.BuildVersion=${{ env.BUILD_VERSION }}" -o ${{env.SERVICE_NAME }}-darwin-amd64 ./cmd/main.go
           GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-X main.BuildVersion=${{ env.BUILD_VERSION }}" -o ${{env.SERVICE_NAME }}-darwin-arm64 ./cmd/main.go
 
       - name: Upload release artifacts
@@ -52,7 +54,49 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ steps.releaser.outputs.tag_name }} ${{env.SERVICE_NAME }}-linux-amd64
           gh release upload ${{ steps.releaser.outputs.tag_name }} ${{env.SERVICE_NAME }}-linux-arm64
-          gh release upload ${{ steps.releaser.outputs.tag_name }} ${{env.SERVICE_NAME }}-darwin-amd64
           gh release upload ${{ steps.releaser.outputs.tag_name }} ${{env.SERVICE_NAME }}-darwin-arm64
+
+      # Use OIDC rather than long-lived IAM credentials. OIDC provider and IAM role needs to be configured in AWS
+      # https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+      - name: Configure AWS credentials
+        if: ${{ steps.releaser.outputs.release_created }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-actions-user-mgmt-service-api-workflow
+          role-session-name: GHActions-user-mgmt-service-api
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        if: ${{ steps.releaser.outputs.release_created }}
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # Required for multi-platform builds
+      # https://docs.docker.com/build/ci/github-actions/multi-platform/
+      # https://docs.docker.com/build/building/multi-platform/#cross-compiling-a-go-application
+      - name: Set up Docker
+        if: ${{ steps.releaser.outputs.release_created }}
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      # Using the "Cross Compilation" method rather than emulation. See Dockerfile variables
+      # Use SemVer tag
+      - name: Build & push multi-architecture Docker image for app
+        if: ${{ steps.releaser.outputs.release_created }}
+        id: docker-image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: user-mgmt-service-api
+          IMAGE_TAG: ${{ steps.releaser.outputs.tag_name }}
+          ARCHITECTURES: linux/amd64,linux/arm64
+        run: |
+          docker build --platform $ARCHITECTURES -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg BUILD_VERSION=$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          echo Pushed $REGISTRY/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-# When raising a PR against the main branch build and push Docker image and then run E2E tests in AWS
+# When raising a PR against the main branch, build and push Docker image and then run E2E tests in AWS.
 # Other tests will also be triggered from the ci.yml workflow
 name: PR against main
 on:
@@ -6,15 +6,15 @@ on:
     branches:
       - main
 
-
-# todo: add a release workflow
-
 permissions:
   id-token: write   # required for requesting the JWT
   contents: read    # required for actions/checkout
 
 jobs:
   e2e-tests:
+    # Do not run if part of the release please workflow (auto-releaser.yml), as the tests have already been run
+    if: ${{ ! contains(github.event.pull_request.body, 'This PR was generated with [Release Please]') }}
+
     runs-on: ubuntu-latest
 
     env:
@@ -57,11 +57,10 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: user-mgmt-service-api
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ci-${{ github.sha }}
           ARCHITECTURES: linux/amd64,linux/arm64
         run: |
-          BUILD_VERSION=$(git rev-parse --short HEAD)
-          docker build --platform $ARCHITECTURES -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg BUILD_VERSION=$BUILD_VERSION .
+          docker build --platform $ARCHITECTURES -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg BUILD_VERSION=$IMAGE_TAG .
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo Pushed $REGISTRY/$REPOSITORY:$IMAGE_TAG
           echo "image=$REGISTRY/$REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
@@ -74,7 +73,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: user-mgmt-service-api
-          IMAGE_TAG: ${{ github.sha }}-db-seeding
+          IMAGE_TAG: ci-${{ github.sha }}-db-seeding
           ARCHITECTURES: linux/amd64,linux/arm64
         run: |
           docker buildx build --platform $ARCHITECTURES -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -f ./db-seed/Dockerfile-db-seed --push .

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ make e2e-tests
 
 ## CI (GitHub Actions)
 
-- Push to any branch will trigger the linter (TODO), unit tests and integration tests
-- PR against the main branch will run the above tests as well as the E2E tests. Docker images in ECR will be based off the branch Git SHAs
-- (TODO): PR which is merged into the main branch will auto create a new GitHub tag and release. Docker images in ECR will be based off the semver tags
+- Push to any branch will trigger the linter (TODO), unit tests and integration tests (Docker Compose)
+- PR against the main branch will run the above tests as well as the E2E tests (deploying into AWS). Docker images in ECR will be based off the Git branch SHAs
+- When the PR is merged into the main branch this will auto create a release PR using a Semantic Version tag via [release please](https://github.com/googleapis/release-please-action)
+- Once the release PR is merged the GitHub release will be created, build binaries attached and Docker images built in ECR using the SemVer tags
 
 ## Endpoints
 

--- a/db-seed/readme.md
+++ b/db-seed/readme.md
@@ -1,0 +1,4 @@
+# readme
+
+Docker image which is used in the E2E tests for seeding the database in AWS with a table and sample data.
+Contains the psql client and SQL scripts which the tests depend on.

--- a/scripts/client.sh
+++ b/scripts/client.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Script for running ad-hoc manual tests of the CRUD endpoints. It's recommended to run the integration tests instead, which automate these using Terratest and Docker Compose
+
 set -eu -o pipefail
 
 url='http://localhost:8080'

--- a/sql/readme.md
+++ b/sql/readme.md
@@ -1,0 +1,4 @@
+# readme
+
+SQL scripts for seeding the Postgres database to test against. These are used as part of the `E2E` tests, `Integration` tests and 
+also when spinning the Docker Compose stack up locally via `make run`.


### PR DESCRIPTION
- Build/push final Docker images based on SemVer tags once release is cut
- Do not re-run the E2E tests when the release branch is created
- Prefix the CI build Docker images so we can clean them up using ECR lifecycle rules