### PR TITLE
fix: allow pipeline to get JWT token

### DIFF
--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write   # required for requesting the JWT
 
 jobs:
   release:


### PR DESCRIPTION
Additional GH Action permission is required when requesting the OIDC JWT to work with AWS