### PR TITLE
Do not run E2E tests if releasing

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+    # Do not run if part of the release please workflow (auto-releaser.yml), as the E2E tests have already been run
+    branches-ignore:
+      - 'release-please-**'
 
 permissions:
   id-token: write   # required for requesting the JWT
@@ -12,9 +15,6 @@ permissions:
 
 jobs:
   e2e-tests:
-    # Do not run if part of the release please workflow (auto-releaser.yml), as the tests have already been run
-    if: ${{ ! contains(github.event.pull_request.body, 'This PR was generated with [Release Please]') }}
-
     runs-on: ubuntu-latest
 
     env:

--- a/README.md
+++ b/README.md
@@ -179,10 +179,9 @@ HTTP/1.1 204 No Content
 ```
 
 ## TODO
-- [ ] Add GitHub workflow for auto releasing on merge into main
-- [ ] Add a GET endpoint for an individual user
 - [ ] Use primary keys in the REST URI's rather than logon names
+- [ ] Add a GET endpoint for an individual user
+- [ ] Replace Gorilla Mux module with standard library HTTP routing functionality
 - [ ] Instrument with Prometheus library
 - [ ] Instrument with OpenTelemetry client
 - [ ] Add OpenAPI docs
-- [ ] Replace Gorilla Mux module with standard library HTTP routing functionality


### PR DESCRIPTION
Exclude at the workflow level rather than job level so we don't have empty workflow runs